### PR TITLE
fix: logo link redirects to domain root instead of site base URL

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -8,7 +8,7 @@
     class="is-highest navbar is-fixed-top"
     location-prefix="{{ $locationPrefix }}"
     logo-icon="{{ $logoIcon | absURL }}"
-    logo-link="{{ "/" | absURL }}"
+    logo-link="{{ .Site.BaseURL }}"
     second-menu-prefix="https://in.qgis.org"
     secondary-menu-config="https://raw.githubusercontent.com/qgis/QGIS-User-Group-Website/main/static/config/navigation.json"
 ></qg-top-nav>


### PR DESCRIPTION
Problem
Clicking the navbar logo on the deployed GitHub Pages site redirected to https://qgis.github.io/ (domain root) instead of https://qgis.github.io/QGIS-UG-India/ (the actual site). This happened because logo-link="/" was passed as a literal string to the <qg-top-nav> web component, which resolved it relative to the browser's current domain at runtime.

### Fix
Changed logo-link="/" to logo-link="{{ .Site.BaseURL }}" in layouts/partials/menu.html. 