### PR TITLE
[Content] Rename tutorial page to learning resources and community to plugins

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -175,6 +175,11 @@ sectionPagesMenu = 'main'
   weight = 60
 
 [[menu.main]]
+  name = "Learning Resources"
+  url = "/learning-resources/"
+  weight = 65
+
+[[menu.main]]
   name = "Blog"
   url = "/blog/"
   weight = 70

--- a/content/learning-resources.md
+++ b/content/learning-resources.md
@@ -1,16 +1,16 @@
 ---
 type: "page"
-title: "Tutorials"
-subtitle: "Learn QGIS with practical guides"
+title: "Learning Resources"
+subtitle: "External tutorials and resources to learn QGIS"
 draft: false
 sidebar: true
 ---
 
 {{< content-start >}}
 
-# Tutorials
+# Learning Resources
 
-Practical QGIS tutorials, including local data, projections, and workflows.
+External QGIS tutorials, playlists, and resources curated by the community.
 
 {{< columns-start >}}
 {{< column-start class="is-flex-direction-column is-full">}}
@@ -47,7 +47,7 @@ Practical QGIS tutorials, including local data, projections, and workflows.
 
 ##### Contribute a Tutorial
 
-Send tutorials or links to [tutorials@example.com].
+Want to share a tutorial or resource? [Get involved]({{< relref "/about" >}}#get-involved).
 
 {{< rich-content-end >}}
 {{< rich-box-end >}}

--- a/content/tutorials/_index.md
+++ b/content/tutorials/_index.md
@@ -1,0 +1,7 @@
+---
+type: "page"
+title: "Tutorials"
+subtitle: "Step-by-step guides by the community"
+draft: false
+sidebar: true
+---

--- a/static/config/navigation.json
+++ b/static/config/navigation.json
@@ -50,6 +50,13 @@
           {
             "type": "second-menu",
             "settings": {
+              "name": "Learning Resources",
+              "href": "/learning-resources/"
+            }
+          },
+          {
+            "type": "second-menu",
+            "settings": {
               "name": "Blog",
               "href": "/blog/"
             }


### PR DESCRIPTION
## Summary
- Created `tutorials/` section for user-submitted tutorials (similar to case-studies and blog)
- Renamed existing `tutorials.md` to `learning-resources.md` for external tutorials and YouTube links
- Renamed `community.md` to `plugins.md` to focus on QGIS plugins
- Updated navigation menus

Closes #38 and #13