### PR TITLE
Simplify top navigation to single QGIS.org link

### DIFF
--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -5,6 +5,39 @@
 // The new theme includes carousel, download, and payrexx components we don't need
 // This is handled by the theme's component system
 
+// Simplified top navigation bar
+.simple-top-nav
+  background-color: #fff
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1)
+  min-height: 52px
+
+  .simple-top-nav-container
+    display: flex
+    align-items: center
+    justify-content: space-between
+    width: 100%
+    padding: 0.5rem 1.5rem
+
+  .simple-top-nav-logo
+    display: flex
+    align-items: center
+    img
+      height: 36px
+      width: auto
+
+  .simple-top-nav-link
+    display: flex
+    align-items: center
+    gap: 0.35rem
+    color: #589632
+    font-weight: 500
+    padding: 0.5rem 1rem
+    border-radius: 4px
+    transition: background-color 0.2s
+    &:hover
+      background-color: #f5f5f5
+      color: #3d7a1c
+
 // Override: Hero section image styling for India UG
 .hero-image
   .hero-container

--- a/layouts/partials/contextmenu.html
+++ b/layouts/partials/contextmenu.html
@@ -1,6 +1,19 @@
 <div class="box mb-0 context-container" id="context">
     <div class="container">
         <nav class="navbar" role="navigation" aria-label="main navigation">
+            <div class="navbar-brand">
+                <a
+                    role="button"
+                    class="navbar-burger"
+                    aria-label="menu"
+                    aria-expanded="false"
+                    data-target="navbarMenu"
+                >
+                    <span aria-hidden="true"></span>
+                    <span aria-hidden="true"></span>
+                    <span aria-hidden="true"></span>
+                </a>
+            </div>
             <div class="navbar-end is-align-items-center is-justify-content-space-between">
 
                 <div class="navbar-item">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -173,11 +173,6 @@
         {{/* Search needs to be rendered as a template to ensure urls are correct */}}
         {{ $searchjs := resources.Get "js/search.js" | resources.ExecuteAsTemplate "search.js" . | resources.Minify | resources.Fingerprint }}
         <script defer src="{{ $searchjs.RelPermalink }}"></script>
-        <script
-            crossorigin=""
-            type="application/javascript"
-            src="{{ .Site.Params.uniNavHeaderUrl }}"
-        ></script>
     </head>
 
     <body></body>

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,14 +1,15 @@
-{{ $isLocal := (or (eq .Site.BaseURL "/") (strings.Contains .Site.BaseURL "localhost")) }}
-{{ $locationPrefix := .Site.Params.uniNavHeaderLocationPrefix }}
-{{ $logoIcon := .Site.Params.uniNavHeaderLogoIcon | default "https://qgis.org/funders/qgis-usergroup-switzerland.png" }}
+{{ $logoIcon := .Site.Params.uniNavHeaderLogoIcon | default "img/qgis_in.png" }}
 
-
-<qg-top-nav
-    breakpoint="1024"
-    class="is-highest navbar is-fixed-top"
-    location-prefix="{{ $locationPrefix }}"
-    logo-icon="{{ $logoIcon | absURL }}"
-    logo-link="{{ .Site.BaseURL }}"
-    second-menu-prefix="https://in.qgis.org"
-    secondary-menu-config="https://qgis.github.io/QGIS-UG-India/config/navigation.json"
-></qg-top-nav>
+<nav class="navbar is-fixed-top simple-top-nav" role="navigation" aria-label="main navigation">
+    <div class="simple-top-nav-container">
+        <a class="simple-top-nav-logo" href="{{ .Site.BaseURL }}">
+            <img src="{{ $logoIcon | absURL }}" alt="QGIS India User Group" />
+        </a>
+        <a class="simple-top-nav-link" href="https://qgis.org" target="_blank" rel="noopener">
+            Visit QGIS.org
+            <span class="icon is-small">
+                <i class="fas fa-external-link-alt"></i>
+            </span>
+        </a>
+    </div>
+</nav>


### PR DESCRIPTION
## Summary
- Replaced the `<qg-top-nav>` web component with a simple static navigation bar
- Top bar now shows only the QGIS India logo (left) and a "Visit QGIS.org" link (right)
- Removed the external `qgis-uni-navigation` script dependency

Fixes #52