### PR TITLE
fix: restore search route and improve navbar search input contrast

### DIFF
--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -69,10 +69,6 @@
       border: none
     &:focus
       background: #fff
-      color: #223745
-      &::placeholder
-        color: #4d6370
-        opacity: 0.7
 
   @media screen and (min-width: 1024px)
     .navbar-start


### PR DESCRIPTION
Description:
## Summary
- add missing `content/search/_index.md` so `/search/` resolves to the existing `search` layout instead of returning 404
## Why
Search queries from the navbar submit to `/search/`, but this route was missing in this site repo.


Closes #77