### PR TITLE
Prepare nix packages, build and tests for migration

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -13,15 +13,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install Nix
       uses: cachix/install-nix-action@v31
   
-    - uses: cachix/cachix-action@v16
-      with:
-        name: qgisugindia
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    # - uses: cachix/cachix-action@v16
+    #   with:
+    #     name: qgisugindia
+    #     authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
     - name: Run flake checks
       run: nix flake check

--- a/.github/workflows/nix-package-test.yml
+++ b/.github/workflows/nix-package-test.yml
@@ -1,0 +1,32 @@
+# Workflow to test Nix packaging on pull requests
+name: 🧪 Test Nix Package
+
+on:
+  pull_request:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  test-nix-package:
+    name: Test Nix Package
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
+
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+  
+    # - name: Set up Cachix
+    #   uses: cachix/cachix-action@v17
+    #   with:
+    #     name: qgiswebsite
+        # Use public cache for reading, no auth token needed
+
+    - name: Run flake checks
+      run: nix flake check --show-trace --accept-flake-config

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ core
 CLAUDE.md
 .claude/*
 !.claude/commands/
+
+# Nix
+result

--- a/flake.nix
+++ b/flake.nix
@@ -126,5 +126,22 @@
           };
         }
       );
+
+      #
+      ### CHECKS
+      #
+
+      checks = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        import ./nix/tests.nix {
+          inherit pkgs;
+          website = self.packages.${system}.website;
+          devShell = self.devShells.${system}.default;
+          websiteApp = self.apps.${system}.website.program;
+        }
+      );
     };
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -6,7 +6,7 @@
 }:
 
 stdenv.mkDerivation {
-  name = "qgis-user-group-website";
+  name = "qgis-user-group-india";
 
   src = lib.cleanSourceWith {
     src = ../.;

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -1,0 +1,133 @@
+{ pkgs, website, devShell, websiteApp }:
+
+{
+  # Smoke test the built website by serving it with Python HTTP server
+  test-smoke = pkgs.runCommand "test-smoke"
+    {
+      inherit website;
+      nativeBuildInputs = [ pkgs.python3 pkgs.curl ];
+    }
+    ''
+      echo "Starting Python HTTP server for smoke tests..."
+
+      PORT=8765
+      python3 -m http.server $PORT --directory "${website}" &
+      SERVER_PID=$!
+
+      # Wait for server to be ready (up to 10 seconds)
+      for i in $(seq 1 20); do
+        if curl -s -o /dev/null "http://127.0.0.1:$PORT/"; then
+          echo "✅ Server is ready"
+          break
+        fi
+        sleep 0.5
+        if [ "$i" = "20" ]; then
+          echo "❌ Server failed to start in time"
+          kill $SERVER_PID 2>/dev/null
+          exit 1
+        fi
+      done
+
+      FAILED=0
+
+      check_content() {
+        local path="$1"
+        local expected="$2"
+        local description="$3"
+
+        if curl -s "http://127.0.0.1:$PORT$path" | grep -q "$expected"; then
+          echo "✅ $description"
+        else
+          echo "❌ $description (expected to find: \"$expected\" at $path)"
+          FAILED=1
+        fi
+      }
+
+      check_status() {
+        local path="$1"
+        local expected_code="$2"
+        local description="$3"
+
+        actual=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:$PORT$path")
+        if [ "$actual" = "$expected_code" ]; then
+          echo "✅ $description (HTTP $actual)"
+        else
+          echo "❌ $description (expected HTTP $expected_code, got HTTP $actual)"
+          FAILED=1
+        fi
+      }
+
+      # Homepage
+      check_status "/" "200" "Homepage returns HTTP 200"
+      check_content "/" "QGIS India User Group" "Homepage has site title"
+      check_content "/" "Welcome to the QGIS India User Group" "Homepage has welcome heading"
+
+      # Key section pages
+      check_status "/about-us/" "200" "About Us page returns HTTP 200"
+      check_content "/about-us/" "About Us" "About Us page has expected content"
+
+      check_status "/events/" "200" "Events page returns HTTP 200"
+      check_content "/events/" "Events" "Events page has expected content"
+
+      check_status "/tutorials/" "200" "Tutorials page returns HTTP 200"
+      check_content "/tutorials/" "Tutorials" "Tutorials page has expected content"
+
+      check_status "/rules/" "200" "Rules page returns HTTP 200"
+      check_content "/rules/" "Rules" "Rules page has expected content"
+
+      # 404 handling
+      check_status "/this-page-does-not-exist/" "404" "Non-existent path returns HTTP 404"
+
+      kill $SERVER_PID 2>/dev/null
+      wait $SERVER_PID 2>/dev/null || true
+
+      if [ "$FAILED" = "1" ]; then
+        echo ""
+        echo "❌ Smoke tests FAILED"
+        exit 1
+      fi
+
+      echo ""
+      echo "✅ All smoke tests passed"
+      echo "Smoke tests passed" > $out
+    '';
+
+  # Test dev shell has required tools
+  test-dev-shell = pkgs.runCommand "test-dev-shell"
+    {
+      nativeBuildInputs = devShell.nativeBuildInputs or [ ]
+        ++ devShell.buildInputs or [ ];
+    }
+    ''
+      echo "Testing dev shell tools..."
+
+      # Check hugo is available
+      if ! command -v hugo &> /dev/null; then
+        echo "❌ hugo not found in dev shell"
+        exit 1
+      fi
+
+      echo "✅ hugo available: $(hugo version)"
+
+      # Check python is available
+      if ! command -v python3 &> /dev/null; then
+        echo "❌ python3 not found in dev shell"
+        exit 1
+      fi
+
+      echo "✅ python3 available: $(python3 --version)"
+
+      # Check make is available
+      if ! command -v make &> /dev/null; then
+        echo "❌ make not found in dev shell"
+        exit 1
+      fi
+
+      echo "✅ make available: $(make --version | head -1)"
+
+      echo "Dev shell verification passed" > $out
+    '';
+
+  # Package builds successfully (implicit check)
+  build-website = website;
+}


### PR DESCRIPTION
- Enable nix build without cachix so it won't generate errors
- Add Nix Package test so it's possible to detect package build erros early from here without going into the production